### PR TITLE
feat(checkbox): make component fully controlled and eliminate React warnings

### DIFF
--- a/src/components/atoms/checkbox/Checkbox.tsx
+++ b/src/components/atoms/checkbox/Checkbox.tsx
@@ -64,7 +64,7 @@ const Checkbox: FC<TypeCheckbox & TypeFluidContainer> = ({
               aria-checked={indeterminate ? "mixed" : checked}
               readOnly
             />
-            <label htmlFor={id ?? generatedId} />
+            <label htmlFor={id ?? generatedId} onClick={(e) => e.stopPropagation()} />
           </div>
         ),
         ...props.prefix,


### PR DESCRIPTION
Exposes `checked` and `onChange` props for proper control. Fixes warning about missing `onChange` when `checked` is provided, preventing read-only field issues.