### PR TITLE
feat: allow passing extra props to DatePicker component

### DIFF
--- a/src/components/atoms/date-picker/DatePicker.tsx
+++ b/src/components/atoms/date-picker/DatePicker.tsx
@@ -4,10 +4,12 @@ import type { DatePickerProps as AntDatePickerProps } from "antd";
 import dayjs, { Dayjs } from "dayjs";
 import styles from "./DatePicker.module.scss";
 
+export type AntDatePickerSharedProps = Omit<AntDatePickerProps, "value" | "onChange">;
+
 type DatePickerProps = {
   onChange?: (value: string | string[]) => void;
   value: Date | string | null | undefined;
-} & Omit<AntDatePickerProps, "value" | "onChange">;
+} & AntDatePickerSharedProps;
 
 const DatePicker = ({ value, onChange, ...props }: DatePickerProps) => {
   const handleOnChange = (date: Dayjs, dateString: string | string[]) => {
@@ -23,7 +25,6 @@ const DatePicker = ({ value, onChange, ...props }: DatePickerProps) => {
       value={normalizedPickerValue}
       onChange={handleOnChange}
       className={`${styles.datePicker} ${props.className}`}
-      getPopupContainer={(triggerNode) => triggerNode.parentElement!}
     />
   );
 };

--- a/src/components/atoms/inputs/normal/date/Date.tsx
+++ b/src/components/atoms/inputs/normal/date/Date.tsx
@@ -3,7 +3,7 @@ import Icon from "@atoms/icon/Icon";
 import styles from "./Date.module.scss";
 import BaseInput from "@atoms/base-input/BaseInput";
 import Text from "@atoms/text/Text";
-import DatePicker from "@atoms/date-picker/DatePicker";
+import DatePicker, { AntDatePickerSharedProps } from "@atoms/date-picker/DatePicker";
 
 type DateRangePickerProps = {
   label?: string;
@@ -12,6 +12,7 @@ type DateRangePickerProps = {
   value?: Date | string | null;
   placeholder?: string;
   inputContainerClassName?: string;
+  datePickerProps?: AntDatePickerSharedProps;
 };
 
 const DateInput: React.FC<DateRangePickerProps> = ({
@@ -21,6 +22,7 @@ const DateInput: React.FC<DateRangePickerProps> = ({
   value,
   placeholder = "",
   inputContainerClassName,
+  datePickerProps,
 }) => {
   const handleOnChange = (dateString: string | string[]) => {
     onChange?.(new Date(dateString as string));
@@ -46,6 +48,7 @@ const DateInput: React.FC<DateRangePickerProps> = ({
         suffixIcon={null}
         onChange={handleOnChange}
         value={value}
+        {...datePickerProps}
       />
     </BaseInput>
   );


### PR DESCRIPTION
Enable consumers to provide additional props to the date picker by exposing a shared props type and forwarding those props. Increases flexibility for date input customization and integration.