### PR TITLE
feat: prevent errors on missing contains method in ref elements

### DIFF
--- a/src/custom-hooks/useOnClickOutside.tsx
+++ b/src/custom-hooks/useOnClickOutside.tsx
@@ -15,9 +15,9 @@ export const useOnClickOutside = ({ targetElements, onClickOutside }: TypeUseOnC
 
       const clickedInsideRefs = targetElements.some((targetElement) => {
         if (targetElement instanceof HTMLElement) {
-          return targetElement.contains(event.target as Node);
+          return targetElement.contains?.(event.target as Node);
         }
-        return targetElement?.current?.contains(event.target as Node);
+        return targetElement?.current?.contains?.(event.target as Node);
       });
 
       if (clickedInsideRefs) return;


### PR DESCRIPTION
Add optional chaining when calling the contains method on elements and refs to avoid runtime errors if these objects are undefined or lack the method. Improves robustness when handling dynamic or non-standard refs in the outside click handler.