### PR TITLE
feat: improve input props and ref handling in relation input

### DIFF
--- a/src/components/atoms/select-option/SelectOption.tsx
+++ b/src/components/atoms/select-option/SelectOption.tsx
@@ -44,7 +44,6 @@ const SelectOption: FC<TypeSelectOption & TypeFluidContainer> = ({
       dimensionY={36}
       alignment="leftCenter"
       onClick={onClick}
-      className={`${styles.option} ${selected && styles.selected} ${disabled && styles.disabled}`}
       root={{
         children: (
           <Checkbox
@@ -63,6 +62,7 @@ const SelectOption: FC<TypeSelectOption & TypeFluidContainer> = ({
         dimensionX: "fill",
       }}
       {...props}
+      className={`${styles.option} ${selected && styles.selected} ${disabled && styles.disabled} ${props.className || ""}`}
     />
   );
 };


### PR DESCRIPTION
Refactor input component props to enhance flexibility by extending base input types and omitting children. Unify and expose imperative refs for dropdowns and selection, enabling better external control. Fixes select option className merging to support custom styles without overriding selection and disabled states.