### PR TITLE
feat: pass custom className to input location component in useInputRepresenter.

### DIFF
--- a/src/custom-hooks/useInputRepresenter.tsx
+++ b/src/custom-hooks/useInputRepresenter.tsx
@@ -265,6 +265,7 @@ const types: TypeInputTypeMap = {
         dimensionX="fill"
         coordinates={props.value as TypeCoordinates}
         onChange={handleChangeLocation}
+        className={props.className}
       />
     );
   },


### PR DESCRIPTION
Allow external customization of the location input.