### PR TITLE
feat: prevents rendering empty description text

### DIFF
--- a/src/components/atoms/inputs/normal/boolean/Boolean.tsx
+++ b/src/components/atoms/inputs/normal/boolean/Boolean.tsx
@@ -56,9 +56,11 @@ const BooleanInput: FC<TypeBooleanInput> = ({
         className={`${containerProps?.className} ${styles.container}`}
         {...containerProps}
       />
-      <Text size="xsmall" className={`${styles.description}`}>
-        {description}
-      </Text>
+      {description && (
+        <Text size="xsmall" className={`${styles.description}`}>
+          {description}
+        </Text>
+      )}
     </FlexElement>
   );
 };


### PR DESCRIPTION
improve UI clarity by rendering the description only when content is provided, avoiding unnecessary empty elements and unnecessary blank spaces created by the gap in the component output.